### PR TITLE
feat: add DDNS Updater Docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ddns-updater-data/

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  ddns-updater:
+    image: qmcgaw/ddns-updater
+    container_name: ddns-updater
+    restart: unless-stopped
+    volumes:
+      - ./ddns-updater-data:/updater/data
+    network_mode: bridge
+    ports:
+      - "8000:8000"
+    environment:
+      - LOG_LEVEL=warning


### PR DESCRIPTION
Create `compose.yaml` to deploy the `qmcgaw/ddns-updater` service. This setup:
- Configures the container to restart unless stopped.
- Maps port 8000:8000 for web UI access.
- Mounts a local volume for data persistence.
- Sets the log level to warning.

Add `.gitignore` to exclude the local `ddns-updater-data/` directory from version control.

Closes #4