### PR TITLE
feat: Configure Caddy as reverse proxy for web traffic

### DIFF
--- a/caddy-conf/Caddyfile
+++ b/caddy-conf/Caddyfile
@@ -1,0 +1,13 @@
+{
+	log {
+		level WARN
+	}
+}
+
+signature-verifier.localhost {
+	reverse_proxy flask:5000
+}
+
+signature-verifier.ddns.net {
+	reverse_proxy flask:5000
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,8 +5,18 @@ services:
     restart: unless-stopped
     volumes:
       - ./ddns-updater-data:/updater/data
-    network_mode: bridge
     ports:
       - "8000:8000"
     environment:
       - LOG_LEVEL=warning
+
+  caddy:
+    image: caddy:latest
+    container_name: caddy
+    restart: unless-stopped
+    volumes:
+      - ./caddy-conf:/etc/caddy
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"


### PR DESCRIPTION
This commit introduces the Caddy web server to handle all incoming HTTP/HTTPS traffic, acting as a reverse proxy for the Flask application.

Key changes:
- Adds the `caddy` service to `compose.yaml`, exposing ports 80 and 443 for external access.
- Creates `caddy-conf/Caddyfile` to define two site blocks:
    - `signature-verifier.localhost`: Enables easy local development access.
    - `signature-verifier.ddns.net`: Routes external traffic from the DDNS domain.
- Both site definitions proxy requests to the internal `flask:5000` service, allowing Caddy to manage SSL/TLS and act as the edge router for the application.

Closes #7